### PR TITLE
use sql queries to display tables

### DIFF
--- a/db/query.sql
+++ b/db/query.sql
@@ -1,17 +1,4 @@
--- Get all employees by roles
-SELECT
-    e.first_name,
-    e.last_name,
-    r.title AS role_title,
-    d.name AS department
-        from employees e
-            JOIN roles r    
-                ON e.role_id = r.id 
-            JOIN departments d
-                ON r.department_id = d.id
-        WHERE r.id = 1; -- Need to pass in the role id here instead of 1 to get all employees in that specific role
-
--- Get all employees
+-- Get all employees by roles and departments
 SELECT
         e.id,
         e.first_name,
@@ -26,3 +13,25 @@ SELECT
             ON r.department_id = d.id
         LEFT JOIN employees managers
             ON e.manager_id = managers.id;
+
+-- Get all employees by specific roles
+SELECT
+    e.first_name,
+    e.last_name,
+    r.title AS role_title,
+    d.name AS department
+        from employees e
+            JOIN roles r    
+                ON e.role_id = r.id 
+            JOIN departments d
+                ON r.department_id = d.id
+        WHERE r.id = 1; -- Need to pass in the role id here instead of 1 to get all employees in that specific role
+
+-- Get all roles with their departments
+SELECT
+    r.title,
+    r.salary,
+    d.name AS department
+        FROM roles r
+            JOIN departments d   
+                ON r.department_id = d.id; 

--- a/index.js
+++ b/index.js
@@ -1,11 +1,7 @@
-const fs = require('fs');
 const inquirer = require('inquirer');
 const { addDepartment, addRole, addEmployee, updateEmployee } = require('./prompts');
-const { viewTable } = require('./queries');
+const { viewDepartments, viewEmployees, viewRoles } = require('./queries');
 const { checkConnection } = require('./db/db');
-
-// Create an array that will hold all of the queries from query.sql
-// const sqlQueries = fs.readFileSync('./db/query.sql', 'utf-8').split(';');
 
 function init() {
     checkConnection(() => mainMenu());
@@ -29,13 +25,13 @@ function mainMenu() {
 function handleMenuOption(option) {
     switch (option) {
         case 'View all departments':
-            viewTable('departments', () => mainMenu());
+            viewDepartments(() => mainMenu());
             break;
         case 'View all roles':
-            viewTable('roles', () => mainMenu());
+            viewRoles(() => mainMenu());
             break;
         case 'View all employees':
-            viewTable('employees', () => mainMenu());
+            viewEmployees(() => mainMenu());
             break;
         case 'Add a department':
             addDepartment(() => mainMenu());

--- a/queries/get_employee_by_id.js
+++ b/queries/get_employee_by_id.js
@@ -1,4 +1,0 @@
-const fs = require('fs');
-const { db } = require('../db/db');
-
-// const sqlQuery = fs.readFileSync('./db/query.sql', 'utf-8').split(';')[1];

--- a/queries/get_employee_by_role.js
+++ b/queries/get_employee_by_role.js
@@ -1,4 +1,0 @@
-const fs = require('fs');
-const { db } = require('../db/db');
-
-// const sqlQuery = fs.readFileSync('./db/query.sql', 'utf-8').split(';')[0];

--- a/queries/index.js
+++ b/queries/index.js
@@ -1,3 +1,5 @@
-const viewTable = require('./view_table');
+const viewEmployees = require('./view_employees');
+const viewRoles = require('./view_roles');
+const viewDepartments = require('./view_departments');
 
-module.exports = { viewTable }
+module.exports = { viewDepartments, viewEmployees, viewRoles }

--- a/queries/view_departments.js
+++ b/queries/view_departments.js
@@ -1,11 +1,11 @@
 const { db } = require('../db/db');
 
-function viewTable (table, callback) {
+function viewDepartments (callback) {
     // Get the table the user is looking for in the database
-    db.query(`SELECT * FROM ${table};`, (err, result) => {
+    db.query('SELECT * FROM departments;', (err, result) => {
         if (err) throw err;
 
-        console.log(`\n${table[0].toUpperCase() + table.slice(1)} Table`);
+        console.log(`\nDepartments Table`);
         console.table(result);
         console.log('\n');
 
@@ -13,4 +13,4 @@ function viewTable (table, callback) {
     });
 }
 
-module.exports = viewTable;
+module.exports = viewDepartments;

--- a/queries/view_employees.js
+++ b/queries/view_employees.js
@@ -1,0 +1,19 @@
+const fs = require('fs');
+const { db } = require('../db/db');
+
+const sqlQuery = fs.readFileSync('./db/query.sql', 'utf-8').split(';')[0];
+
+function viewEmployees (callback) {
+    // Get the table the user is looking for in the database
+    db.query(sqlQuery, (err, result) => {
+        if (err) throw err;
+
+        console.log(`\nEmployees Table`);
+        console.table(result);
+        console.log('\n');
+
+        callback();
+    });
+}
+
+module.exports = viewEmployees;

--- a/queries/view_roles.js
+++ b/queries/view_roles.js
@@ -1,0 +1,19 @@
+const fs = require('fs');
+const { db } = require('../db/db');
+
+const sqlQuery = fs.readFileSync('./db/query.sql', 'utf-8').split(';')[2];
+
+function viewRoles (callback) {
+    // Get the table the user is looking for in the database
+    db.query(sqlQuery, (err, result) => {
+        if (err) throw err;
+
+        console.log(`\nRoles Table`);
+        console.table(result);
+        console.log('\n');
+
+        callback();
+    });
+}
+
+module.exports = viewRoles;


### PR DESCRIPTION
This PR uses the sql queries inside query.sql to join the necessary tables together allowing users to see the departments associated with each role in the roles table and the departments and roles associated with each employee in the employees table 